### PR TITLE
3.5 Possibly make holder class notation more explicit

### DIFF
--- a/lectures/nn_kernels/nn_kernels.tex
+++ b/lectures/nn_kernels/nn_kernels.tex
@@ -586,12 +586,12 @@ D^\alpha f = \frac{\partial^{|\alpha|} f}{\partial x_1^{\alpha_1} \partial
 For an integer $r \geq 0$, exponent $0 < \gamma \leq 1$, radius $L>0$, and
 domain $U \subseteq \R^d$, we now define the H{\"o}lder class  
 \[
-C^{r+\gamma}(L; U) = \Big\{ f : U \to \R \,:\, | D^\alpha f (x) - D^\alpha f(y)
+C^{r,\gamma}(L; U) = \Big\{ f : U \to \R \,:\, | D^\alpha f (x) - D^\alpha f(y)
 | \leq L \|x-y\|_2^\gamma \; \text{for all $|\alpha| = r$, and $x,y \in U$}
 \Big\}.   
 \]
-Note that $C^1(L; U)$ is simply the space of all $L$-Lipschitz functions on
-$U$. Likewise, for an integer $k \geq 1$, $C^k(L; U)$ is the space of all
+Note that $C^{0,1}(L; U)$ is simply the space of all $L$-Lipschitz functions on
+$U$. Likewise, for an integer $k \geq 1$, $C^{k-1,1}(L; U)$ is the space of all
 functions on $U$ whose order $\alpha\th$ derivative is $L$-Lipschitz, for all
 $\alpha = k-1$.
 


### PR DESCRIPTION
If I understand the proposed definition of the Holder class, I wonder if it would be clearer to notate the Holder class by the tuple (r, \gamma) instead of the sum r+ \gamma

See proposed change below:
![image](https://github.com/ryantibs/statlearn-s24/assets/61856489/f5756b30-5921-4752-80bb-49fa64d4e6fc)
