### PR TITLE
Update holder class definition to have order derivative up to k

### DIFF
--- a/lectures/nn_kernels/nn_kernels.tex
+++ b/lectures/nn_kernels/nn_kernels.tex
@@ -589,13 +589,13 @@ For an integer $r \geq 0$, exponent $0 < \gamma \leq 1$, radius $L>0$, and
 domain $U \subseteq \R^d$, we now define the H{\"o}lder class  
 \[
 C^{r+\gamma}(L; U) = \Big\{ f : U \to \R \,:\, | D^\alpha f (x) - D^\alpha f(y)
-| \leq L \|x-y\|_2^\gamma \; \text{for all $|\alpha| = r$, and $x,y \in U$}
+| \leq L \|x-y\|_2^\gamma \; \text{for all $|\alpha| \leq r$, and $x,y \in U$}
 \Big\}.   
 \]
 Note that $C^1(L; U)$ is simply the space of all $L$-Lipschitz functions on
 $U$. Likewise, for an integer $k \geq 1$, $C^k(L; U)$ is the space of all
 functions on $U$ whose order $\alpha\th$ derivative is $L$-Lipschitz, for all
-$\alpha = k-1$.
+$\alpha \leq k-1$.
 
 It can be shown that a minimax lower bound over $C^s(L; [0,1]^d)$, for a
 constant $L>0$, is    


### PR DESCRIPTION
Updating to holder class definition such that order derivative is up to k, to match what is introduced in lecture